### PR TITLE
Open stderr reporting file for writing

### DIFF
--- a/amun/inspect.py
+++ b/amun/inspect.py
@@ -48,7 +48,7 @@ def main():
 
     # Execute the supplied script.
     args = ['pipenv', 'run', _EXEC_FILE]
-    with open(_EXEC_STDOUT_FILE, 'w') as stdout_file, open(_EXEC_STDERR_FILE) as stderr_file:
+    with open(_EXEC_STDOUT_FILE, 'w') as stdout_file, open(_EXEC_STDERR_FILE, 'w') as stderr_file:
         process = subprocess.Popen(args, stdout=stdout_file, stderr=stderr_file, universal_newlines=True)
         process.wait()
 


### PR DESCRIPTION
Without this, the child process was unable to capture stdandard error output to
opened file and failed with non-zero exit code causing inspections always to
fail.