### PR TITLE
Keep requirements optional

### DIFF
--- a/openshift/inspectJob-template.yaml
+++ b/openshift/inspectJob-template.yaml
@@ -86,10 +86,8 @@ parameters:
     description: CPU cores requested for build
     displayName: Build CPU
     default: 750m
-    required: true
 
   - name: AMUN_MEMORY
     description: Memory requested for build
     displayName: Build Memory
     default: 256Mi
-    required: true

--- a/openshift/inspectJobWithCPU-template.yaml
+++ b/openshift/inspectJobWithCPU-template.yaml
@@ -107,13 +107,11 @@ parameters:
     description: CPU cores requested for build
     displayName: Build CPU
     default: 750m
-    required: true
 
   - name: AMUN_MEMORY
     description: Memory requested for build
     displayName: Build Memory
     default: 256Mi
-    required: true
 
   - name: CPU_FAMILY
     description: Family number of CPU.


### PR DESCRIPTION
This way we can expand them in the workload operator without a need to process
template.