### PR TITLE
Cleanup in templates

### DIFF
--- a/amun/api_v1.py
+++ b/amun/api_v1.py
@@ -78,7 +78,7 @@ def _generate_inspection_id():
     # but it looks like there is a bug in OpenShift as it did not generated any
     # name and failed with regexp issues (that were not related to the
     # generateName configuration).
-    return 'inspect-' + "%016x" % random.getrandbits(64)
+    return 'inspection-' + "%016x" % random.getrandbits(64)
 
 
 def post_generate_dockerfile(specification: dict):

--- a/openshift/inspectBuildConfig-template.yaml
+++ b/openshift/inspectBuildConfig-template.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: amun-inspect-buildconfig
+  name: amun-inspection-buildconfig
   annotations:
     description: A template for BuildConfig to create build on the fly.
-    openshift.io/display-name: Amun inspect BuildConfig
+    openshift.io/display-name: Amun inspection BuildConfig
     version: 0.0.1
     tags: poc,amun,thoth,ai-stacks
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
@@ -12,9 +12,9 @@ metadata:
       A template used to create dynamic builds on user requests.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: amun-inspect-buildconfig
+    template: amun-inspection-buildconfig
     app: amun
-    component: inspect-buildconfig
+    component: amun-inspection-buildconfig
 
 objects:
   - kind: BuildConfig
@@ -23,7 +23,7 @@ objects:
       name: "${AMUN_INSPECTION_ID}"
       labels:
         app: amun
-        component: inspect-buildconfig
+        component: amun-inspection-buildconfig
         mark: cleanup
       annotations:
         amun_specification: ${AMUN_SPECIFICATION}

--- a/openshift/inspectBuildConfigWithCPU-template.yaml
+++ b/openshift/inspectBuildConfigWithCPU-template.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: amun-inspect-buildconfig-with-cpu
+  name: amun-inspection-buildconfig-with-cpu
   annotations:
     description: A template for BuildConfig to create build on the fly.
-    openshift.io/display-name: Amun inspect BuildConfig
+    openshift.io/display-name: Amun inspection BuildConfig
     version: 0.0.1
     tags: poc,amun,thoth,ai-stacks
     template.openshift.io/documentation-url: https://github.com/Thoth-Station/
@@ -12,9 +12,9 @@ metadata:
       A template used to create dynamic builds on user requests.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: amun-inspect-buildconfig-with-cpu
+    template: amun-inspection-buildconfig-with-cpu
     app: amun
-    component: inspect-buildconfig
+    component: amun-inspection-buildconfig
 
 objects:
   - kind: BuildConfig
@@ -23,7 +23,7 @@ objects:
       name: "${AMUN_INSPECTION_ID}"
       labels:
         app: amun
-        component: inspect-buildconfig
+        component: amun-inspection-buildconfig
         mark: cleanup
       annotations:
         amun_specification: ${AMUN_SPECIFICATION}

--- a/openshift/inspectImageStream-template.yaml
+++ b/openshift/inspectImageStream-template.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: amun-inspect-imagestream
+  name: amun-inspection-imagestream
   annotations:
     description: >
       This is Thoth Adviser ImageStream, this template is meant to be used by Jenkins, but could also
       be used by humans
-    openshift.io/display-name: Dynamically generated ImageStream for dynamic inspect builds.
+    openshift.io/display-name: Dynamically generated ImageStream for dynamic inspection builds.
     version: 0.2.0
     tags: poc,amun,thoth,ai-stacks,adviser
     template.openshift.io/documentation-url: https://github.com/Thoth-Station
@@ -16,8 +16,8 @@ metadata:
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
     app: amun
-    component: inspect-imagestream
-    template: amun-inspect-imagestream
+    component: amun-inspection-imagestream
+    template: amun-inspection-imagestream
 
 objects:
   - apiVersion: image.openshift.io/v1
@@ -25,7 +25,7 @@ objects:
     metadata:
       labels:
         app: amun
-        component: inspect-imagestream
+        component: amun-inspection-imagestream
         mark: cleanup
       name: ${AMUN_INSPECTION_ID}
     spec:

--- a/openshift/inspectJob-template.yaml
+++ b/openshift/inspectJob-template.yaml
@@ -1,7 +1,7 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: amun-inspect-job
+  name: amun-inspection-job
   annotations:
     description: Amun - Execution engine for Thoth
     openshift.io/display-name: Amun API
@@ -12,9 +12,9 @@ metadata:
       This template defines resources needed to run Amun's inspection job on OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: amun-inspect-job
+    template: amun-inspection-job
     app: amun
-    component: amun-inspect
+    component: amun-inspection-job
 
 objects:
   - apiVersion: batch/v1
@@ -23,18 +23,20 @@ objects:
       name: "${AMUN_INSPECTION_ID}"
       labels:
         app: amun
-        component: amun-inspect
+        component: amun-inspection-job
         operator: graph-sync
         task: inspection
         mark: cleanup
+        amun_template: amun-inspection-job
     spec:
       backoffLimit: 0
       template:
         metadata:
           labels:
             app: amun
-            component: amun-inspect
+            component: amun-inspection-job
             mark: cleanup
+            amun_template: amun-inspection-job
         spec:
           automountServiceAccountToken: false
           restartPolicy: Never

--- a/openshift/inspectJobWithCPU-template.yaml
+++ b/openshift/inspectJobWithCPU-template.yaml
@@ -1,7 +1,7 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: amun-inspect-job-with-cpu
+  name: amun-inspection-job-with-cpu
   annotations:
     description: Amun - Execution engine for Thoth
     openshift.io/display-name: Amun API
@@ -12,9 +12,9 @@ metadata:
       This template defines resources needed to run Amun's inspection job on OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: amun-inspect-job-with-cpu
+    template: amun-inspection-job-with-cpu
     app: amun
-    component: amun-inspect
+    component: amun-inspection-job
 
 objects:
   - apiVersion: batch/v1
@@ -23,7 +23,8 @@ objects:
       name: "${AMUN_INSPECTION_ID}"
       labels:
         app: amun
-        component: amun-inspect
+        component: amun-inspection-job
+        amun_template: amun-inspection-job-with-cpu
         operator: graph-sync
         task: inspection
         mark: cleanup
@@ -33,7 +34,8 @@ objects:
         metadata:
           labels:
             app: amun
-            component: amun-inspect
+            component: amun-inspection-job
+            amun_template: amun-inspection-job-with-cpu
             mark: cleanup
         spec:
           automountServiceAccountToken: false

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -39,7 +39,28 @@ objects:
         name: inspector
         namespace: ${AMUN_API_NAMESPACE}
 
+  # TODO: do not assign cluser-wise edit, but define own Amun roles
+  - apiVersion: v1
+    kind: RoleBinding
+    metadata:
+      name: role-inspector-binding
+      namespace: ${AMUN_API_NAMESPACE}
+      labels:
+        app: amun
+    roleRef:
+      kind: ClusterRole
+      name: edit
+    subjects:
+      - kind: ServiceAccount
+        name: inspector
+        namespace: ${AMUN_API_NAMESPACE}
+
 parameters:
+  - description: Namespace for infrastructure for Amun.
+    displayName: Amun Infra Namespace
+    required: true
+    name: AMUN_INFRA_NAMESPACE
+
   - description: Namespace where Amun API service sits.
     displayName: Amun API Namespace
     required: true


### PR DESCRIPTION
This patch addresses confusion when querying inspection jobs done in the cluster:

* fix missleading 'amun-inspect', 'inspect' or 'inspection' labelling
* add label for querying template-specific inspections (e.g. with CPU/GPU specification)
* name inspection jobs with 'inspection-' prefix rather than 'inspect-'