### PR TITLE
Update job templates with imagestream info

### DIFF
--- a/openshift/inspectJob-template.yaml
+++ b/openshift/inspectJob-template.yaml
@@ -62,7 +62,7 @@ objects:
                   name: hw-info-volume
           initContainers:
             - name: inspect-hwinfo
-              image: inspect-hwinfo
+              image: "${THOTH_REGISTRY}/${THOTH_INFRA_NAMESPACE}/inspect-hwinfo"
               volumeMounts:
                 - mountPath: /home/amun/hwinfo
                   name: hw-info-volume
@@ -79,6 +79,16 @@ objects:
               name: '${AMUN_INSPECTION_ID}:latest'
 
 parameters:
+  - name: THOTH_REGISTRY
+    description: Registry server from where Image is to be pulled
+    displayName: Registry
+    required: true
+
+  - name: THOTH_INFRA_NAMESPACE
+    description: Project where ImageStream is present
+    displayName: ImageStream Project
+    required: true
+
   - name: AMUN_INSPECTION_ID
     description: Id of inspection that is run.
     displayName: Inspection id

--- a/openshift/inspectJobWithCPU-template.yaml
+++ b/openshift/inspectJobWithCPU-template.yaml
@@ -62,7 +62,7 @@ objects:
                   name: hw-info-volume
           initContainers:
             - name: inspect-hwinfo
-              image: inspect-hwinfo
+              image: "${THOTH_REGISTRY}/${THOTH_INFRA_NAMESPACE}/inspect-hwinfo"
               volumeMounts:
                 - mountPath: /home/amun/hwinfo
                   name: hw-info-volume
@@ -100,6 +100,16 @@ objects:
                       - ${PROCESSOR}
 
 parameters:
+  - name: THOTH_REGISTRY
+    description: Registry server from where Image is to be pulled
+    displayName: Registry
+    required: true
+
+  - name: THOTH_INFRA_NAMESPACE
+    description: Project where ImageStream is present
+    displayName: ImageStream Project
+    required: true
+
   - name: AMUN_INSPECTION_ID
     description: Id of inspection that is run.
     displayName: Inspection id


### PR DESCRIPTION
Issue fixed by the PR:
- Observed the `thoth-amun-inspection` namespace looks up local `inspect-hwinfo` image stream from images, whereas it should pull image from its infra environment i.e thoth-test-core.
- User has specified manually the image in the stage environment but not in the test environment. 