### PR TITLE
Update the trigger-build job to use the latest job API

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -11,7 +11,9 @@
       jobs:
         - "trigger-build":
             vars:
-              webhook_url: "https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/amun-api"
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "amun-api"
     kebechet-auto-gate:
       queue: "thoth-station/amun-api"
       jobs:

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -57,6 +57,10 @@ objects:
         - type: ConfigChange
         - type: ImageChange
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
 
 parameters:
   - description: Name of the GitHub repository for Amun API


### PR DESCRIPTION
Update buildconfig template to allow the buildconfig listen to generic webhook and update the zuul config file to use the latest version of trigger-build job API.