### PR TITLE
Extend Amun specification and docker file

### DIFF
--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -50,7 +50,7 @@ def _determine_installer_string() -> str:
 
 
 def _obtain_script(script: str) -> str:
-    """Obrain script if it was specified by an URL, if script was provided inline, return it."""
+    """Obtain script if it was specified by an URL, if script was provided inline, return it."""
     if script.startswith(('https://', 'http://')):
         # Download script from remote if needed.
         response = requests.get(script)
@@ -89,6 +89,9 @@ def create_dockerfile(specification: dict) -> tuple:
 
     if specification.get('packages'):
         dockerfile += _determine_installer_string() + " ".join(specification['packages']) + '\n\n'
+
+    if specification.get('python_packages'):
+        dockerfile += "RUN pip3 install " + " ".join(specification["python_packages"]) + '\n\n'
 
     for file_spec in specification.get('files', []):
         path = file_spec['path']

--- a/amun/inspect.py
+++ b/amun/inspect.py
@@ -17,8 +17,8 @@
 
 """This file is run by an inspection pod to gather runtime information.
 
-This script should not use any extern libraries except for Python's standard
-library. It acts as an wrapper around user supplied script and prints command
+This script should not use any external libraries except for Python's standard
+library. It acts as wrapper around user supplied script and prints command
 results to stdout as a JSON. It also aggregates information from hwinfo
 init-container aggregating hardware information.
 """

--- a/amun/swagger.yaml
+++ b/amun/swagger.yaml
@@ -187,6 +187,13 @@ definitions:
           type: string
           description: Name of the package to be installed.
           example: 'vim'
+      python_packages:
+        type: array
+        description: A list of python packages that should be installed into the runtime environment.
+        items:
+          type: string
+          description: Name of the package to be installed.
+          example: 'pipenv'
       python:
         type: object
         description: Python application stack to be installed.


### PR DESCRIPTION
Amun specification inputs are extended with python packages
DockerFile is extended and it can install python packges if the list of python packages is not empty

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>