### PR TITLE
Fix function call

### DIFF
--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -92,7 +92,7 @@ def create_dockerfile(specification: dict) -> tuple:
 
     # Updating the base has to be turned on explicitly.
     if specification.get('update', False):
-        dockerfile += _determine_update_string
+        dockerfile += _determine_update_string()
 
     if specification.get('packages'):
         dockerfile += _determine_installer_string() + " ".join(specification['packages']) + '\n\n'


### PR DESCRIPTION
Fixes: https://github.com/thoth-station/amun-api/issues/230

```

File "/opt/app-root/src/amun/dockerfile.py", line 95, in create_dockerfile
--
  | dockerfile += _determine_update_string
  | TypeError: must be str, not function


```