### PR TITLE
Fix escaping of quotes when writing Pipfile.lock

### DIFF
--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -71,8 +71,8 @@ def _write_file_string(content: str, path: str) -> str:
     # TODO: accept a list of files so we generate only one layer for all files
     # TODO: escape content
     # TODO: handle it in nice way so we can see it nicely in OpenShift's configuration
-    content = content.replace('"', '\\"').replace('\n', '\\n\\\n')
-    path = path.replace('"', '\"')
+    content = content.replace("\\", "\\\\").replace('"', '\\"').replace('\n', '\\n\\\n')
+    path = path.replace('"', '\\"')
     return f'RUN echo -e "{content}" >"{path}"\n'
 
 


### PR DESCRIPTION
This caused that Pipenv silently failed to parse Pipfile.lock and the whole
`pipenv install --deploy' went into a weird state causing installation issues.
This was observed only if environment markers that have quote present were used
(e.g. TensorFlow stack).