### PR TITLE
Added different function for \n

### DIFF
--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -78,6 +78,16 @@ def _write_file_string(content: str, path: str) -> str:
     # TODO: accept a list of files so we generate only one layer for all files
     # TODO: escape content
     # TODO: handle it in nice way so we can see it nicely in OpenShift's configuration
+    content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\\\n")
+    path = path.replace('"', '"')
+    return f"RUN echo -e $'{content}' > '{path}'\n\n"
+
+
+def _write_file_entrypoint(content: str, path: str) -> str:
+    """Generate Dockerfile instruction that writes down the file content on the given path."""
+    # TODO: accept a list of files so we generate only one layer for all files
+    # TODO: escape content
+    # TODO: handle it in nice way so we can see it nicely in OpenShift's configuration
     content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n\\\\n")
     path = path.replace('"', '"')
     return f'RUN echo -e "{content}" > "{path}"\n\n'
@@ -161,7 +171,7 @@ def create_dockerfile(specification: dict) -> tuple:
         content = _obtain_script(specification["script"])
         dockerfile += _write_file_string(content, "/home/amun/script")
         with open(_ENTRYPOINT_PY, "r") as entrypoint_file:
-            dockerfile += _write_file_string(
+            dockerfile += _write_file_entrypoint(
                 entrypoint_file.read(), "/home/amun/entrypoint"
             )
 

--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -75,19 +75,19 @@ def _obtain_script(script: str) -> str:
 
 def _write_file_string(content: str, path: str) -> str:
     """Generate Dockerfile instruction that writes down the file content on the given path."""
-    content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\\\n")
-    path = path.replace('"', '"')
-    return f"RUN echo -e $'{content}' > '{path}'\n\n"
-
-
-def _write_file_entrypoint(content: str, path: str) -> str:
-    """Generate Dockerfile instruction that writes down the file content on the given path."""
     # TODO: accept a list of files so we generate only one layer for all files
     # TODO: escape content
     # TODO: handle it in nice way so we can see it nicely in OpenShift's configuration
     content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n\\\\n")
     path = path.replace('"', '"')
     return f'RUN echo -e "{content}" > "{path}"\n\n'
+
+
+def _write_file_script(content: str, path: str) -> str:
+    """Generate Dockerfile instruction that writes down the file content on the given path."""
+    content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\\\n")
+    path = path.replace('"', '"')
+    return f"RUN echo -e $'{content}' > '{path}'\n\n"
 
 
 def create_dockerfile(specification: dict) -> tuple:
@@ -166,9 +166,9 @@ def create_dockerfile(specification: dict) -> tuple:
     if "script" in specification:
         script_present = True
         content = _obtain_script(specification["script"])
-        dockerfile += _write_file_string(content, "/home/amun/script")
+        dockerfile += _write_file_script(content, "/home/amun/script")
         with open(_ENTRYPOINT_PY, "r") as entrypoint_file:
-            dockerfile += _write_file_entrypoint(
+            dockerfile += _write_file_string(
                 entrypoint_file.read(), "/home/amun/entrypoint"
             )
 

--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -75,9 +75,6 @@ def _obtain_script(script: str) -> str:
 
 def _write_file_string(content: str, path: str) -> str:
     """Generate Dockerfile instruction that writes down the file content on the given path."""
-    # TODO: accept a list of files so we generate only one layer for all files
-    # TODO: escape content
-    # TODO: handle it in nice way so we can see it nicely in OpenShift's configuration
     content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\\\n")
     path = path.replace('"', '"')
     return f"RUN echo -e $'{content}' > '{path}'\n\n"

--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -87,7 +87,7 @@ def _write_file_script(content: str, path: str) -> str:
     """Generate Dockerfile instruction that writes down the file content on the given path."""
     content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\\\n")
     path = path.replace('"', '"')
-    return f"RUN echo -e $'{content}' > '{path}'\n\n"
+    return f'RUN echo -e "{content}" > "{path}"\n\n'
 
 
 def create_dockerfile(specification: dict) -> tuple:
@@ -142,12 +142,12 @@ def create_dockerfile(specification: dict) -> tuple:
             )
         else:
             pipfile_content = toml.dumps(requirements)
-            dockerfile += _write_file_string(pipfile_content, "/home/amun/Pipfile")
+            dockerfile += _write_file_script(pipfile_content, "/home/amun/Pipfile")
 
             pipfile_lock_content = json.dumps(
                 requirements_locked, sort_keys=True, indent=4
             )
-            dockerfile += _write_file_string(
+            dockerfile += _write_file_script(
                 pipfile_lock_content, "/home/amun/Pipfile.lock"
             )
 


### PR DESCRIPTION
Closes #127 
Sample docker file generated - https://paste.ofcode.org/33QsfYngtMiKcRCmA3Rn7MH
So using removing the extra `\\n`, was leading to fail for entrypoint, so I moved it to a different function and changed the `_write_file_string`. 
Ref - http://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
Is this the right way to do it?