### PR TITLE
Parameters in Workflow template is not read

### DIFF
--- a/openshift/amunInspectionWorkflow-template.yaml
+++ b/openshift/amunInspectionWorkflow-template.yaml
@@ -49,7 +49,7 @@ objects:
       - name: batch-size
         value: '1'
       - name: batch-name
-        value: "{{workflow.parameters.inspection-id}}"
+        value: "${AMUN_INSPECTION_ID}"
       - name: allowed-failures
         value: '1'  # i.e., 99% success rate out of 100
       - name: parallelism

--- a/openshift/amunInspectionWorkflowWithCPU-template.yaml
+++ b/openshift/amunInspectionWorkflowWithCPU-template.yaml
@@ -49,7 +49,7 @@ objects:
       - name: batch-size
         value: '1'
       - name: batch-name
-        value: "{{workflow.parameters.inspection-id}}"
+        value: "${AMUN_INSPECTION_ID}"
       - name: allowed-failures
         value: '1'  # i.e., 99% success rate out of 100
       - name: parallelism


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

If you have a look at one inspection workflow:

```
  target:            inspection-run-result
  ceph_bucket_prefix: data/thoth
  ceph_bucket_name:  thoth
  ceph_host:         https://s3.upshift.redhat.com/
  deployment_name:   thoth-psi-stage
  allowed-failures:  1
  batch-size:        100
  parallelism:       1
  inspection-id:     inspection-cvut-6-eaf73dc5
  batch-name:        {{workflow.parameters.inspection-id}}
  cpu:               1
  memory:            3Gi
  registry:          docker-registry.default.svc:5000
  thoth-infra-namespace: thoth-infra-stage

```