### PR TITLE
Write results to file not to stdandard output

### DIFF
--- a/amun/inspect.py
+++ b/amun/inspect.py
@@ -40,6 +40,7 @@ _HWINFO_FILE = "/home/amun/hwinfo/info.json"
 # We use a file for stdout and stderr not to block on pipe.
 _EXEC_STDOUT_FILE = "/home/amun/script.stdout"
 _EXEC_STDERR_FILE = "/home/amun/script.stderr"
+_EXEC_RESULT = "/home/amun/output"
 # Executable to be run.
 _EXEC_DIR = "/home/amun"
 _EXEC_FILE = os.path.join(_EXEC_DIR, "script")
@@ -171,16 +172,9 @@ def main():
         "runtime_environment": runtime_environment
     }
 
-    output = json.dumps(report, sort_keys=True, indent=2)
+    with open(_EXEC_RESULT, "w") as output_file:
+        json.dump(report, output_file, indent=2, sort_keys=True)
 
-    output_fp = os.environ.get("THOTH_OUTPUT_ARTIFACT")
-    if output_fp:
-        output_file = Path(output_fp)
-
-        output_file.touch(exist_ok=True)
-        output_file.write_text(output)
-
-    sys.stdout.write(output)
     sys.exit(report["exit_code"])
 
 

--- a/workflows/templates/inspection-results-template.yaml
+++ b/workflows/templates/inspection-results-template.yaml
@@ -6,7 +6,7 @@ kind: WorkflowTemplate
 metadata:
   name: inspection-results-template
   annotations:
-    thoth-station.ninja/template-version: 0.6.0
+    thoth-station.ninja/template-version: 0.6.1
 spec:
   templates:
   - name: main
@@ -18,8 +18,6 @@ spec:
       # Default
       - name: namespace
         value: "{{workflow.namespace}}"
-      - name: kind
-        value: pods
       - name: selector
         value: ""
       - name: registry
@@ -46,7 +44,7 @@ spec:
         set -euxo pipefail
 
         resource_names=$(\
-          kubectl get {{inputs.parameters.kind}}        \
+          kubectl get pods \
             --namespace {{inputs.parameters.namespace}} \
             --selector {{inputs.parameters.selector}}   \
             --output json |\
@@ -59,7 +57,10 @@ spec:
           cnt=0
           IFS=$'\n' ; for name in $resource_names; do
             let "cnt+=1";
-            kubectl logs $name > "${results}/${cnt}-output"
+            kubectl logs $name > "${results}/${cnt}-logs"
+            kubectl cp --container=main \
+              "{{inputs.parameters.namespace}}/$name:/home/amun/output" \
+              "${results}/${cnt}-output"
           done
         }
 
@@ -68,13 +69,13 @@ spec:
           exit 1
         fi
 
-        cat <<EOF | jq . >"${results}/Dockerfile"
+        cat <<__EOF__ | jq . >"${results}/Dockerfile"
         {{inputs.parameters.dockerfile}}
-        EOF
+        __EOF__
 
-        cat <<EOF >"${results}/specification"
+        cat <<__EOF__ >"${results}/specification"
         {{inputs.parameters.specification}}
-        EOF
+        __EOF__
 
       resources:
         limits:


### PR DESCRIPTION
With this change all the results will be aggregated to a file instead of
printing them to stdout. This simplifies performance indicators handling that
were printing to stound/stderr from a forked process causing serialization
issues when the output was expected to be a JSON output (printed logs bloated
output). Also, with this fix we do not rely on OpenShift to store logs - these
logs were automatically deleted after some time causing troubles aggregating
them when they were no longer available.