### PR TITLE
Revert "Write results to file not to stdandard output"

### DIFF
--- a/amun/inspect.py
+++ b/amun/inspect.py
@@ -40,7 +40,6 @@ _HWINFO_FILE = "/home/amun/hwinfo/info.json"
 # We use a file for stdout and stderr not to block on pipe.
 _EXEC_STDOUT_FILE = "/home/amun/script.stdout"
 _EXEC_STDERR_FILE = "/home/amun/script.stderr"
-_EXEC_RESULT = "/home/amun/output"
 # Executable to be run.
 _EXEC_DIR = "/home/amun"
 _EXEC_FILE = os.path.join(_EXEC_DIR, "script")
@@ -172,9 +171,16 @@ def main():
         "runtime_environment": runtime_environment
     }
 
-    with open(_EXEC_RESULT, "w") as output_file:
-        json.dump(report, output_file, indent=2, sort_keys=True)
+    output = json.dumps(report, sort_keys=True, indent=2)
 
+    output_fp = os.environ.get("THOTH_OUTPUT_ARTIFACT")
+    if output_fp:
+        output_file = Path(output_fp)
+
+        output_file.touch(exist_ok=True)
+        output_file.write_text(output)
+
+    sys.stdout.write(output)
     sys.exit(report["exit_code"])
 
 

--- a/workflows/templates/inspection-results-template.yaml
+++ b/workflows/templates/inspection-results-template.yaml
@@ -6,7 +6,7 @@ kind: WorkflowTemplate
 metadata:
   name: inspection-results-template
   annotations:
-    thoth-station.ninja/template-version: 0.6.1
+    thoth-station.ninja/template-version: 0.6.0
 spec:
   templates:
   - name: main
@@ -18,6 +18,8 @@ spec:
       # Default
       - name: namespace
         value: "{{workflow.namespace}}"
+      - name: kind
+        value: pods
       - name: selector
         value: ""
       - name: registry
@@ -44,7 +46,7 @@ spec:
         set -euxo pipefail
 
         resource_names=$(\
-          kubectl get pods \
+          kubectl get {{inputs.parameters.kind}}        \
             --namespace {{inputs.parameters.namespace}} \
             --selector {{inputs.parameters.selector}}   \
             --output json |\
@@ -57,10 +59,7 @@ spec:
           cnt=0
           IFS=$'\n' ; for name in $resource_names; do
             let "cnt+=1";
-            kubectl logs $name > "${results}/${cnt}-logs"
-            kubectl cp --container=main \
-              "{{inputs.parameters.namespace}}/$name:/home/amun/output" \
-              "${results}/${cnt}-output"
+            kubectl logs $name > "${results}/${cnt}-output"
           done
         }
 
@@ -69,13 +68,13 @@ spec:
           exit 1
         fi
 
-        cat <<__EOF__ | jq . >"${results}/Dockerfile"
+        cat <<EOF | jq . >"${results}/Dockerfile"
         {{inputs.parameters.dockerfile}}
-        __EOF__
+        EOF
 
-        cat <<__EOF__ >"${results}/specification"
+        cat <<EOF >"${results}/specification"
         {{inputs.parameters.specification}}
-        __EOF__
+        EOF
 
       resources:
         limits:


### PR DESCRIPTION
Reverts thoth-station/amun-api#376

It turned out we cannot do it this way.

https://github.com/kubernetes/kubectl/issues/454