### PR TITLE
Do not print results to pod logs

### DIFF
--- a/amun/inspect.py
+++ b/amun/inspect.py
@@ -182,7 +182,6 @@ def main():
         with open(output_fp, "w") as output_file:
             output_file.write(output)
 
-    sys.stdout.write(output)
     sys.exit(report["exit_code"])
 
 


### PR DESCRIPTION
As we aggregate results using Argo artifacts, we do not need to print results to stdout anymore. The output of container is captured and placed on Ceph. The output can be used by libraries to produce info/warning/error messages.

With this change, we do not need to patch libraries that produced messages which verbosity was out of our control.