### PR TITLE
allow amun-api to use printf with valid delimiters

### DIFF
--- a/amun/api_v1.py
+++ b/amun/api_v1.py
@@ -349,6 +349,6 @@ def get_inspection(page: Optional[int], limit: Optional[int]) -> Dict[str, Any]:
     page = 1 if page is None or page <= 0 else page
     limit = _PAGE_LIMIT if limit is None or limit <= 0 or limit > _PAGE_LIMIT else limit
     return {
-        "inspections":  itertools.islice(InspectionStore.iter_inspections(), page - 1, limit),
-        "parameters": {"page": page, "limit": limit}
+        "inspections": itertools.islice(InspectionStore.iter_inspections(), page - 1, limit),
+        "parameters": {"page": page, "limit": limit},
     }

--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -80,7 +80,7 @@ def _write_file_string(content: str, path: str) -> str:
 
 def _write_file_script(content: str, path: str) -> str:
     """Generate Dockerfile instruction that writes down the file content on the given path."""
-    content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\\\n")
+    content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\\\n").replace("%", "%%")
     path = path.replace('"', '"')
     return f'RUN printf "{content}" > "{path}"\n\n'
 


### PR DESCRIPTION
allow amun-api to use printf with valid delimiters
fixes: `line 0: printf: `Y': invalid format character caused by  
`\"datetime\": datetime.utcnow().strftime(\"%Y-%m-%dT%H:%M:%S.%f\")`
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>