### PR TITLE
add delimiter to the write_to_string function

### DIFF
--- a/amun/dockerfile.py
+++ b/amun/dockerfile.py
@@ -73,7 +73,7 @@ def _write_file_string(content: str, path: str) -> str:
     # TODO: accept a list of files so we generate only one layer for all files
     # TODO: escape content
     # TODO: handle it in nice way so we can see it nicely in OpenShift's configuration
-    content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n\\\\n")
+    content = content.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n\\\\n").replace("%", "%%")
     path = path.replace('"', '"')
     return f'RUN printf "{content}" > "{path}"\n\n'
 


### PR DESCRIPTION
add delimiter to the write_to_script function

Related-To: #505 
issue arise from this function, via https://github.com/thoth-station/amun-api/blob/0d7cb8671a352d9c5e98195e99b7f6ec1aa304ef/amun/dockerfile.py#L161

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>