### PR TITLE
Use thoth-s2i image as a default value in api schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -357,7 +357,7 @@ components:
           type: string
           minLength: 1
           description: Base image on which the runtime environment should be based on.
-          example: 'quay.io/thoth-station/s2i-thoth-ubi8-py38'
+          example: 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.3'
         identifier:
           type: string
           description: >-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -357,7 +357,7 @@ components:
           type: string
           minLength: 1
           description: Base image on which the runtime environment should be based on.
-          example: 'registry.access.redhat.com/ubi8/python-36'
+          example: 'quay.io/thoth-station/s2i-thoth-ubi8-py38'
         identifier:
           type: string
           description: >-


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/thoth-application/issues/2496 

## This introduces a breaking change

- No

## This Pull Request implements

Use the `s2i-thoth-ubi8-py38` base image as a default value in the `/inspect` endpoint. The current default value `registry.access.redhat.com/ubi8/python-36` does not have pipenv or micropipenv available, and as @fridex mentioned it would be better to use our own containerized environment to see how packages behave in them.
