### PR TITLE
Make runtime_environment and constraints optional

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -401,8 +401,6 @@ components:
           required:
             - requirements
             - requirements_locked
-            - runtime_environment
-            - constraints
           properties:
             requirements:
               type: object


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes schema validation that expects runtime_environment and constraints to be always present.